### PR TITLE
Add null possibility to return type of microdata

### DIFF
--- a/src/microdata.ts
+++ b/src/microdata.ts
@@ -13,7 +13,7 @@ export function microdata<T>(
   itemtype: string,
   scope: Scope,
   extractValue: ExtractValue = () => undefined
-): T {
+): T | null {
   const itemScope = scope.querySelector(`[itemscope][itemtype="${itemtype}"]`)
   return itemScope === null ? null : extract(itemScope, extractValue)
 }


### PR DESCRIPTION
### 🤔 What's changed?

Add null possibility to return type of microdata

### ⚡️ What's your motivation? 

`microdata<Foo>(...)` currently says it would only return `Foo` but it may return `Foo | null`

### 🏷️ What kind of change is this?

- :boom: Breaking change (will cause existing user behaviour to not
  work it did before)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.