### PR TITLE
CI: drop Node 14 from build matrix

### DIFF
--- a/.github/workflows/test-javascript.yml
+++ b/.github/workflows/test-javascript.yml
@@ -15,7 +15,7 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-        node-version: ['14.x', '16.11.x', '17.x', '18.x']
+        node-version: ['16.11', 17, 18, 20]
 
     steps:
       - name: set git core.autocrlf to 'input'


### PR DESCRIPTION
### 🤔 What's changed?

- Drop Node 14
- Add Node 20.
- Use a more terse syntax to specify the versions in the CI matrix configuration - I used this documentation: https://github.com/actions/setup-node/#supported-version-syntax

### ⚡️ What's your motivation? 

Get to green!

There were failed automated PRs, failing on npm packages that this package depends on no longer supporting Node 14.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

Is this the right place to manage the CI configuration for this project?

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

