### PR TITLE
Allow boolean as return value for extractValued

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- `extractValue` can return booleans too.
 
 ## [2.1.0] - 2022-07-27
 ### Added

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ function value(element: Element, extractValue: ExtractValue) {
   }
 
   if (typeof rawValue === 'boolean') {
-    return  rawValue;
+    return rawValue
   }
 
   const stringValue = rawValue

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,17 +68,22 @@ function value(element: Element, extractValue: ExtractValue) {
   }
   const attributeName = attributeNameByTagName[element.tagName.toLowerCase()]
   const extractedValue = extractValue(element)
-  const rawStringValue =
+  const rawValue =
     extractedValue === undefined
       ? attributeName
         ? element.getAttribute(attributeName)
         : element.textContent
       : extractedValue
 
-  if (rawStringValue === null) {
+  if (rawValue === null) {
     throw new Error(`Unable to extract value`)
   }
-  const stringValue = rawStringValue
+
+  if (typeof rawValue === 'boolean') {
+    return  rawValue;
+  }
+
+  const stringValue = rawValue
     .trim()
     .split(/\n/)
     .map((s) => s.trim())
@@ -136,5 +141,5 @@ const attributeNameByTagName: { [key: string]: string } = {
   time: 'datetime',
 }
 
-type ExtractValue = (element: Element) => string | undefined | null
+type ExtractValue = (element: Element) => string | boolean | undefined | null
 type Scope = Document | Element

--- a/test/acceptanceTest.ts
+++ b/test/acceptanceTest.ts
@@ -5,7 +5,7 @@ import assert from 'assert'
 
 describe('microdata', () => {
   context(
-    'acceptace tests from https://github.com/schemaorg/schemaorg/blob/master/data/examples.txt',
+    'acceptance tests from https://github.com/schemaorg/schemaorg/blob/master/data/examples.txt',
     () => {
       it('makes a https://schema.org/Person', () => {
         const html = `<!DOCTYPE html>

--- a/test/microdataTest.ts
+++ b/test/microdataTest.ts
@@ -182,25 +182,31 @@ describe('microdata', () => {
     assert.strictEqual(person.givenName, '')
   })
 
-  it('can extract booleans', () => {
+  it('can extract boolean value with extractValue', () => {
     const dom = new JSDOM(`<!DOCTYPE html>
 <div itemscope itemtype="https://schema.org/Book">
   <div itemprop="abstract" itemtype="https://schema.org/Text">
-    A quick explanation about the bool
+    A quick explanation about the book
   </div>
-  <span itemprop="abridged" itemtype="https://schema.org/Boolean">Yes</span>
+  <span itemprop="abridged" itemtype="https://schema.org/Boolean">Y</span>
 </div>
 `);
 
-    const person = microdata(
-      'https://schema.org/Person',
+    const book = microdata(
+      'https://schema.org/Book',
       dom.window.document.documentElement,
       (element) => {
         if (element.getAttribute('itemtype') === 'https://schema.org/Boolean') {
-          return element.textContent === 'Yes';
+          return element.textContent === 'Y';
         }
       },
-    )!
+    )
+
+    assert.deepStrictEqual(book, {
+      '@type': 'Book',
+      abstract: 'A quick explanation about the book',
+      abridged: true
+    })
   })
 
   describe('toArray', () => {

--- a/test/microdataTest.ts
+++ b/test/microdataTest.ts
@@ -182,6 +182,27 @@ describe('microdata', () => {
     assert.strictEqual(person.givenName, '')
   })
 
+  it('can extract booleans', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>
+<div itemscope itemtype="https://schema.org/Book">
+  <div itemprop="abstract" itemtype="https://schema.org/Text">
+    A quick explanation about the bool
+  </div>
+  <span itemprop="abridged" itemtype="https://schema.org/Boolean">Yes</span>
+</div>
+`);
+
+    const person = microdata(
+      'https://schema.org/Person',
+      dom.window.document.documentElement,
+      (element) => {
+        if (element.getAttribute('itemtype') === 'https://schema.org/Boolean') {
+          return element.textContent === 'Yes';
+        }
+      },
+    )!
+  })
+
   describe('toArray', () => {
     it('converts two children to array with two elements', () => {
       const dom = new JSDOM(`<!DOCTYPE html>
@@ -233,7 +254,7 @@ describe('microdata', () => {
       assert.deepStrictEqual(dressNames, ['Dresses'])
     })
 
-    it('converts no childred to array with zero elements', () => {
+    it('converts no children to array with zero elements', () => {
       const dom = new JSDOM(`<!DOCTYPE html>
 <ol itemscope itemtype="https://schema.org/BreadcrumbList">
 </ol>

--- a/test/microdataTest.ts
+++ b/test/microdataTest.ts
@@ -190,22 +190,22 @@ describe('microdata', () => {
   </div>
   <span itemprop="abridged" itemtype="https://schema.org/Boolean">Y</span>
 </div>
-`);
+`)
 
     const book = microdata(
       'https://schema.org/Book',
       dom.window.document.documentElement,
       (element) => {
         if (element.getAttribute('itemtype') === 'https://schema.org/Boolean') {
-          return element.textContent === 'Y';
+          return element.textContent === 'Y'
         }
-      },
+      }
     )
 
     assert.deepStrictEqual(book, {
       '@type': 'Book',
       abstract: 'A quick explanation about the book',
-      abridged: true
+      abridged: true,
     })
   })
 


### PR DESCRIPTION
### 🤔 What's changed?

`extractValue` can now also return boolean values (instead of only `string | undefined | null`)

### ⚡️ What's your motivation? 

Being able to extract boolean values without having to add extra dom content such as `itemtype="https://schema.org/Boolean" content="false"`

### 🏷️ What kind of change is this?

Honestly, not really sure if it's a fix or a new feature...

- :bug: Bug fix (non-breaking change which fixes a defect)
- :zap: New feature (non-breaking change which adds new behaviour)


### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
